### PR TITLE
Improve cli config options and types for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ sm-webpack serve --dev-port 3050
 ### Using with config
 
 Add a `sm-webpack.js` file to your project's root directory with the config for your project exported.
+Or add a "sm-webpack" key to your package.json.
 
 Eg. sm-webpack.js:
 ```js

--- a/bin/sm-webpack-cli.js
+++ b/bin/sm-webpack-cli.js
@@ -96,10 +96,11 @@ async function runAndExit() {
 	if (!extraConf.publicUrl) {
 		extraConf.publicUrl = `/${extraConf.destPath}`;
 	}
+	const webpackConfig = extraConf.webpackConfig || {};
 	try {
 		if (build) {
 			console.time('Built', config || '');
-			await smWebpack.runProdWebpack({config: extraConf});
+			await smWebpack.runProdWebpack({config: extraConf, webpackConfig});
 			console.timeEnd('Built', config || '');
 			process.exit(0);
 		}
@@ -107,7 +108,7 @@ async function runAndExit() {
 			if (!Number.isSafeInteger(extraConf.devServer.port)) {
 				throw new Error('Invalid port');
 			}
-			await smWebpack.runDevServer({config: extraConf});
+			await smWebpack.runDevServer({config: extraConf, webpackConfig});
 			console.log(`[smWebpack] Running Dev Server${config ? ' ' + config : ''}!`);
 		}
 	}

--- a/bin/sm-webpack-cli.js
+++ b/bin/sm-webpack-cli.js
@@ -84,6 +84,7 @@ async function runAndExit() {
 		else if (!config) {
 			_.merge(extraConf, conf);
 		}
+		else throw new Error(`Invalid config option: ${config}`);
 	}
 	_.defaultsDeep(extraConf, options, {
 		sourcePath: 'res',
@@ -118,4 +119,6 @@ async function runAndExit() {
 	}
 }
 
-runAndExit();
+runAndExit().catch((err) => {
+	console.error(err);
+});

--- a/bin/sm-webpack-cli.js
+++ b/bin/sm-webpack-cli.js
@@ -5,7 +5,8 @@ const {version} = require('../package.json');
 const smWebpack = require('../index');
 
 const confFile = `${process.cwd()}/sm-webpack`;
-const packageFile = `${process.cwd()}/package.json`;
+// One config for all Smartprix packages
+const smartprixConfFile = `${process.cwd()}/sm-config`;
 
 program
 	.version(version, '-v, --version')
@@ -56,11 +57,11 @@ async function runAndExit() {
 	}
 	catch (e) {
 		try {
-			conf = require(packageFile)['sm-webpack']; // eslint-disable-line
-			if (!conf || _.isEmpty(conf)) throw new Error('No config in package.json');
+			conf = require(smartprixConfFile)['sm-webpack']; // eslint-disable-line
+			if (!conf || _.isEmpty(conf)) throw new Error('No config in common sm-config file');
 		}
 		catch (err) {
-			console.log('[smWebpack] Conf not found or error in config', e, err);
+			console.log('[smWebpack] Conf not found or error in config', e.message, err.message);
 			conf = {};
 		}
 	}

--- a/bin/sm-webpack-cli.js
+++ b/bin/sm-webpack-cli.js
@@ -5,6 +5,7 @@ const {version} = require('../package.json');
 const smWebpack = require('../index');
 
 const confFile = `${process.cwd()}/sm-webpack`;
+const packageFile = `${process.cwd()}/package.json`;
 
 program
 	.version(version, '-v, --version')
@@ -53,9 +54,15 @@ async function runAndExit() {
 	try {
 		conf = require(confFile); // eslint-disable-line
 	}
-	catch (err) {
-		console.log('[smWebpack] Conf not found or error in config', err);
-		conf = {};
+	catch (e) {
+		try {
+			conf = require(packageFile)['sm-webpack']; // eslint-disable-line
+			if (!conf || _.isEmpty(conf)) throw new Error('No config in package.json');
+		}
+		catch (err) {
+			console.log('[smWebpack] Conf not found or error in config', e, err);
+			conf = {};
+		}
 	}
 
 	if (!_.isEmpty(conf)) {

--- a/config/babel.js
+++ b/config/babel.js
@@ -25,6 +25,7 @@ function getBabelConfig(config = {}) {
 	const excludePresets = options.excludePresets || [];
 	const includePlugins = options.includePlugins || [];
 	const excludePlugins = options.excludePlugins || [];
+	const includeModules = options.includeModules || [];
 
 	const presets = [];
 	const addPreset = (preset, opts) => {
@@ -76,6 +77,7 @@ function getBabelConfig(config = {}) {
 	return {
 		options: {
 			debug: envOptions.debug,
+			includeModules,
 		},
 		babelrc: false,
 		presets,

--- a/config/babel.js
+++ b/config/babel.js
@@ -74,7 +74,9 @@ function getBabelConfig(config = {}) {
 	plugins.push(...includePlugins);
 
 	return {
-		debug: envOptions.debug,
+		options: {
+			debug: envOptions.debug,
+		},
 		babelrc: false,
 		presets,
 		plugins,

--- a/config/babel.js
+++ b/config/babel.js
@@ -74,6 +74,7 @@ function getBabelConfig(config = {}) {
 	plugins.push(...includePlugins);
 
 	return {
+		debug: envOptions.debug,
 		babelrc: false,
 		presets,
 		plugins,

--- a/config/loaders.js
+++ b/config/loaders.js
@@ -35,6 +35,8 @@ function getCacheConfig(config, id, options = {}) {
 
 function getJsLoader(config) {
 	const babelConfig = getBabelConfig(config);
+	const debug = babelConfig.debug;
+	delete babelConfig.debug;
 	const cacheConfig = getCacheConfig(config, 'babel-loader', {
 		modules: [
 			'@babel/core',
@@ -65,7 +67,7 @@ function getJsLoader(config) {
 			if (filePath.includes('node_modules')) return true;
 			return false;
 		},
-		use: [
+		use: debug ? babelLoader : [
 			cacheLoader,
 			babelLoader,
 		],

--- a/config/loaders.js
+++ b/config/loaders.js
@@ -35,8 +35,8 @@ function getCacheConfig(config, id, options = {}) {
 
 function getJsLoader(config) {
 	const babelConfig = getBabelConfig(config);
-	const debug = babelConfig.debug;
-	delete babelConfig.debug;
+	const {debug} = babelConfig.options;
+	delete babelConfig.options;
 	const cacheConfig = getCacheConfig(config, 'babel-loader', {
 		modules: [
 			'@babel/core',

--- a/config/loaders.js
+++ b/config/loaders.js
@@ -223,7 +223,7 @@ function getStyleLoader(loaders, options = {}, config) {
 	// enable module support
 	if (options.modules) {
 		cssLoader[1].modules = true;
-		let localIdentName = '[hash:base64:6]';
+		let localIdentName = '[hash:base62:6]';
 		if (!config.isProduction) {
 			localIdentName = `[name]_[local]_${localIdentName}`;
 		}

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -14,6 +14,11 @@ const {VueLoaderPlugin} = require('vue-loader');
 
 const getDevServerUrls = require('../util/getDevServerUrls');
 
+/**
+ * Generate dist index.html with correct asset hash for caching.
+ * you can customize output by editing /index.html
+ * @see https://github.com/ampedandwired/html-webpack-plugin
+ */
 function getHtmlWebpackPlugin(config = {}) {
 	// eslint-disable-next-line
 	const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -33,9 +38,6 @@ function getHtmlWebpackPlugin(config = {}) {
 		};
 	}
 
-	// generate dist index.html with correct asset hash for caching.
-	// you can customize output by editing /index.html
-	// see https://github.com/ampedandwired/html-webpack-plugin
 	return new HtmlWebpackPlugin({
 		filename: `${config.entryHtml}`,
 		template: path.join(config.sourcePath, config.entryHtml),
@@ -61,11 +63,13 @@ function getCompressionPlugin() {
 	});
 }
 
+/**
+ * generate bundle size stats so we can analyze them
+ * to see which dependecies are the heaviest
+ */
 function getBundleAnalyzerPlugin(config) {
 	const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 
-	// generate bundle size stats so we can analyze them
-	// to see which dependecies are the heaviest
 	const options = {
 		analyzerMode: 'static',
 		reportFilename: 'webpack.report.html',

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -23,10 +23,12 @@ function getFileName(config) {
 	return 'js/[name].js';
 }
 
-// options is {env, config, webpackConfig}
-// env can be developement or production
-// config gets merged into our default config
-// webpackConfig gets merged into final webpack config
+/**
+ * @param options it is {env, config, webpackConfig}
+ * env can be developement or production
+ * config gets merged into our default config
+ * webpackConfig gets merged into final webpack config
+ */
 function getWebpackConfig(options = {}) {
 	const env = options.env || process.env.NODE_ENV || 'development';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,200 @@
+import {Configuration as devServerConf} from 'webpack-dev-server'
+import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
+import {Configuration as webpackConfiguration} from 'webpack';
+import {RollupBuild} from 'rollup';
+import {EventEmitter} from 'events';
+
+declare module 'sm-webpack-config' {
+	interface BabelConfig {
+		/**
+		 * @see https://babeljs.io/docs/en/babel-preset-env#options
+		 */
+		envOptions?: {
+			loose?: boolean;
+			modules?: string | boolean;
+			useBuiltIns?: false | 'entry' | 'usage';
+			corejs?: number;
+			targets: {
+				esmodules?: boolean;
+				chrome?: string;
+				browsers?: string[];
+			},
+			shippedProposals?: boolean;
+			exclude?: string | string[] | RegExp;
+		}
+		/**
+		 * @see https://www.npmjs.com/package/babel-plugin-transform-imports#options
+		 */
+		transformImports?: {
+			[module: string]: {
+				transform: string | ((importName: string, matches) => string);
+				preventFullImport?: boolean;
+				camelCase?: boolean;
+				kebabCase?: boolean;
+				snakeCase?: boolean;
+				skipDefaultConversion?: boolean;
+			}
+		};
+		includePresets?: (string | [string, any])[];
+		/**
+		 * '@babel/preset-env' is added by default
+		 */
+		excludePresets?: string[];
+		includePlugins?: (string | [string, any])[];
+		/**
+		 * #### These are added by default:
+		 * - @babel/plugin-syntax-dynamic-import
+		 * - @babel/plugin-syntax-import-meta
+		 * - @babel/plugin-proposal-class-properties
+		 * - @babel/plugin-syntax-jsx
+		 * - babel-plugin-transform-vue-jsx
+		 * - @babel/plugin-proposal-optional-chaining
+		 * - @babel/plugin-proposal-nullish-coalescing-operator
+		 * - babel-plugin-transform-imports
+		 * - @babel/plugin-transform-runtime
+		 */
+		excludePlugins?: string[];
+		debug?: boolean;
+	}
+
+	interface DevServerConf extends devServerConf {
+		wwwHost?: string;
+		appHost?: string;
+		appPort?: number;
+		notifyOnError?: boolean;
+		open?: boolean;
+		buildSSR?: boolean;
+	}
+
+	interface BaseConfig {
+		/**
+		 * @default 'res'
+		 */
+		sourcePath?: string;
+		/**
+		 * @default 'static/dist/dev'
+		 * 'static/dist' in production
+		 */
+		destPath?: string;
+		/**
+		 * @default '/static/dist/dev'
+		 */
+		publicUrl?: string;
+		sourceMap?: boolean;
+		eslint?: boolean;
+		entry?: {
+			[app: string]: string;
+		},
+		/**
+		 * Generate dist index.html with correct asset hash for caching.
+		 * you can customize output by editing /index.html
+		 * @see https://github.com/ampedandwired/html-webpack-plugin
+		 * @default index.html
+		 */
+		entryHtml?: boolean | string;
+		appendHash?: boolean;
+		library?: boolean;
+		minify?: boolean;
+		gzip?: boolean;
+		quiet?: boolean;
+		/**
+		 * Generate bundle size stats so we can analyze them
+		 * to see which dependecies are the heaviest
+		 * @see https://www.npmjs.com/package/webpack-bundle-analyzer
+		 */
+		analyzeBundle?: boolean | BundleAnalyzerPlugin.Options;
+		ssr?: boolean | {
+			entry?: string;
+			sourceMap?: boolean;
+		};
+		cwd?: string;
+		cssModules?: boolean;
+		/**
+		 * @see https://github.com/webpack/webpack-dev-server
+		 */
+		devServer?: Partial<DevServerConf>
+		/**
+		 * Open dev server url after starting it
+		 * Default: true
+		 */
+		openBrowser?: boolean;
+		/**
+		 * 'babel-loader' options
+		 */
+		babel?: BabelConfig;
+	}
+
+	export interface Config extends BaseConfig {
+		/**
+		 * NOTE: This is only used when called through CLI, it is ignored when called through function
+		 */
+		webpackConfig: Partial<webpackConfig>;
+		$env_development?: Partial<BaseConfig>;
+		$env_production?: Partial<BaseConfig>;
+	}
+
+	interface RollupBaseConfig {
+		entry?: string;
+		dest?: string;
+		library?: string;
+		libraryFormat?: string;
+		minify?: boolean;
+		sourceMap?: boolean;
+		/**
+		 * 'rollup-plugin-babel' options
+		 */
+		babel?: BabelConfig;
+	}
+
+	export interface RollupConfig extends RollupBaseConfig {
+		$env_development?: Partial<RollupBaseConfig>;
+		$env_production?: Partial<RollupBaseConfig>;
+	}
+
+	export type webpackConfig = webpackConfiguration;
+
+	/**
+	 * @param options it is {env, config, webpackConfig}
+	 * env can be developement or production
+	 * config gets merged into our default config
+	 * webpackConfig gets merged into final webpack config
+	 * @returns merged webpack config
+	 */
+	export function getWebpackConfig(options?: {env?: string, config?: Config, webpackConfig?: webpackConfig}): webpackConfig;
+	/**
+	 * Same as getWebpackConfig but sets environment to production
+	 */
+	export function getProdConfig(options?: {config?: Config, webpackConfig?: webpackConfig}): webpackConfig;
+	/**
+	 * Same as getWebpackConfig but sets environment to developement
+	 */
+	export function getDevConfig(options?: {config?: Config, webpackConfig?: webpackConfig}): webpackConfig;
+	/**
+	 * Run webpack with config provided
+	 */
+	export function runWebpack(options?: {env?: string, config?: Config, webpackConfig?: webpackConfig}): Promise<void>;
+	/**
+	 * Same as runWebpack but sets environment to developement
+	 */
+	export function runDevWebpack(options?: {config?: Config, webpackConfig?: webpackConfig}): Promise<void>;
+	/**
+	 * Same as runWebpack but sets environment to production
+	 */
+	export function runProdWebpack(options?: {config?: Config, webpackConfig?: webpackConfig}): Promise<void>;
+	/**
+	 * Starts dev server with hot reloading
+	 * @see https://github.com/webpack/webpack-dev-server
+	 */
+	export function runDevServer(options?: {config?: Config, webpackConfig?: webpackConfig}): Promise<void>;
+	/**
+	 * @see https://github.com/webpack/webpack-dev-middleware
+	 */
+	export function koaDevServer(options?: {config?: Config, webpackConfig?: webpackConfig}): {middleware: () => (ctx, nxt) => Promise<void>, on: EventEmitter};
+
+	/**
+	 * Run rollup build
+	 * env is taken from NODE_ENV
+	 */
+	export function runRollup(options?: {config?: RollupBaseConfig}): Promise<RollupBuild>;
+
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module 'sm-webpack-config' {
 			},
 			shippedProposals?: boolean;
 			exclude?: string | string[] | RegExp;
+			debug?: boolean;
 		}
 		/**
 		 * @see https://www.npmjs.com/package/babel-plugin-transform-imports#options
@@ -54,6 +55,11 @@ declare module 'sm-webpack-config' {
 		 * - @babel/plugin-transform-runtime
 		 */
 		excludePlugins?: string[];
+		/**
+		 * Mention node_modules that need to be compiled by babel
+		 * Or a regex pattern that matches modules
+		 */
+		includeModules?: string[] | RegExp;
 		debug?: boolean;
 	}
 

--- a/index.js
+++ b/index.js
@@ -4,16 +4,16 @@ const webpack = require('webpack');
 const chalk = require('chalk');
 
 const {getWebpackConfig} = require('./config/webpack');
-const {getConfig, getRollupConfig} = require('./config/default');
+const {getRollupConfig} = require('./config/default');
 const {getDevServerConfig} = require('./config/devServer');
 const {getCompiler} = require('./config/devCompiler');
 
 function getProdConfig({config, webpackConfig}) {
-	return getConfig({env: 'production', config, webpackConfig});
+	return getWebpackConfig({env: 'production', config, webpackConfig});
 }
 
 function getDevConfig({config, webpackConfig}) {
-	return getConfig({env: 'development', config, webpackConfig});
+	return getWebpackConfig({env: 'development', config, webpackConfig});
 }
 
 function runWebpack({env, config, webpackConfig}) {

--- a/index.js
+++ b/index.js
@@ -31,9 +31,7 @@ function runWebpack({env, config, webpackConfig}) {
 			if (!config.isSSR) {
 				console.log(formatStats(stats, config.destPath));
 			}
-
-			// give time to webpack bundle analyzer to output stats
-			setImmediate(resolve);
+			resolve();
 		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "directories": {
     "test": "test"
   },
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run lint && npm run test-only",
     "lint": "eslint src"
@@ -31,6 +32,9 @@
     "@babel/preset-stage-3": "^7.0.0",
     "@babel/register": "^7.4.0",
     "@babel/runtime": "^7.4.3",
+    "@types/webpack": "^4.4.31",
+    "@types/webpack-bundle-analyzer": "^2.13.1",
+    "@types/webpack-dev-server": "^3.1.5",
     "address": "^1.0.3",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-loader": "8.0.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"lib": ["es2015"]
+	},
+	"include": [
+		"index.d.ts"
+	],
+}

--- a/util/formatStats.js
+++ b/util/formatStats.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
-https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/commands/build/formatStats.js
+/**
+ * @see https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/commands/build/formatStats.js
+ */
 module.exports = function formatStats (stats, dir) {
 	const fs = require('fs')
 	const path = require('path')


### PR DESCRIPTION
- Read config in this order:
  - `sm-webpack.js`; if not found then
  - `sm-webpack` key `sm-config.js`; if not found then
  - `sm-webpack` key in `package.json`
- Also now pass `webpackConfig` field as `webpackConfig` to merge
- Add index.d.ts file with types for config
- Fix `getProdConfig` and `getDevConfig` functions
- Disable cache-loader for babel if debug is true
- Close #10 